### PR TITLE
Sync with SVF master: LLVM 21.1.0, drop deadsnakes

### DIFF
--- a/.github/workflows/svf-teaching.yml
+++ b/.github/workflows/svf-teaching.yml
@@ -31,8 +31,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get update
           sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
 
       # install llvm and svf
@@ -43,7 +41,7 @@ jobs:
       - name: build
         run: |
           export SVF_DIR=$(npm root)/SVF
-          export LLVM_DIR=$(npm root)/llvm-18.1.0.obj
+          export LLVM_DIR=$(npm root)/llvm-21.1.0.obj
           export Z3_DIR=$(npm root)/z3.obj
           echo "SVF_DIR="$SVF_DIR
           echo "LLVM_DIR="$LLVM_DIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,28 +8,23 @@ ARG TARGETPLATFORM
 RUN set -e
 
 # Define LLVM version.
-ENV llvm_version=18.1.0
+ENV llvm_version=21.1.0
 
 # Define home directory
 ENV HOME=/home/SVF-tools
 
 # Define dependencies.
-ENV lib_deps="cmake g++ gcc git zlib1g-dev libncurses5-dev libtinfo6 build-essential libssl-dev libpcre2-dev zip libzstd-dev"
-ENV build_deps="wget xz-utils git gdb tcl software-properties-common"
+# Use the default python3-dev that ships with the Ubuntu base image (24.04
+# ships python 3.12) instead of pulling python3.10-dev from a PPA — the
+# Launchpad PPA infrastructure has been intermittently unreachable
+# (HTTP 504 from add-apt-repository), and SVF itself does not pin a Python
+# version, so the base-image python is sufficient.
+ENV lib_deps="cmake g++ gcc git zlib1g-dev libncurses5-dev libtinfo6 build-essential libssl-dev libpcre2-dev zip libzstd-dev python3-dev"
+ENV build_deps="wget xz-utils git gdb tcl"
 
 # Fetch dependencies.
 RUN apt-get update --fix-missing
 RUN apt-get install -y $build_deps $lib_deps
-
-# Add deadsnakes PPA for multiple Python versions
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y python3.10-dev python3.10-venv python3-pip \
-    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
-# Bootstrap pip for Python 3.10 and install packages
-RUN python3 -m ensurepip --upgrade \
-    && python3 -m pip install --break-system-packages --extra-index-url https://test.pypi.org/simple/ pysvf \
-    && python3 -m pip install --break-system-packages z3-solver
 
 # Fetch and build SVF source.
 RUN echo "Downloading LLVM and building SVF to " ${HOME}

--- a/env.sh
+++ b/env.sh
@@ -7,10 +7,10 @@ PROJECTHOME=$(pwd)
 sysOS=`uname -s`
 
 # Set the major version of LLVM
-MajorLLVMVer=16
+MajorLLVMVer=21
 
 # Define the full LLVM version
-LLVMVer=${MajorLLVMVer}.0.0
+LLVMVer=${MajorLLVMVer}.1.0
 
 # Set the home directories for LLVM and Z3
 LLVMHome="llvm-${LLVMVer}.obj"


### PR DESCRIPTION
## Summary

CI Docker build (run [25652449822](https://github.com/SVF-tools/Software-Analysis-Studio/actions/runs/25652449822)) fails at `cmake -DCMAKE_BUILD_TYPE=Debug .` because the Dockerfile pins `llvm_version=18.1.0` while upstream `SVF/build.sh` bumped to `MajorLLVMVer=21 / LLVMVer=21.1.0`. After `bash ./build.sh debug`, `${HOME}/SVF/llvm-21.1.0.obj` exists but `LLVM_DIR` points at the non-existent `llvm-18.1.0.obj`, so `find_package(LLVM REQUIRED CONFIG)` fails.

Mirrors the changes the upstream SVF Dockerfile already made.

## Changes

- **`Dockerfile`** — `llvm_version=18.1.0 → 21.1.0`; drop the `deadsnakes` PPA + `python3.10-dev` + `pip install pysvf z3-solver` block (SVF master no longer installs Python this way, and the SAS repo has no Python assignments that depend on `pysvf`); add `python3-dev` to `lib_deps`; drop `software-properties-common` from `build_deps`.
- **`env.sh`** — `MajorLLVMVer=16 → 21`, `LLVMVer=${MajorLLVMVer}.0.0 → ${MajorLLVMVer}.1.0` to match `SVF/build.sh:26-27`.
- **`.github/workflows/svf-teaching.yml`** — `npm root/llvm-18.1.0.obj → llvm-21.1.0.obj`; drop `ppa:ubuntu-toolchain-r/test` (Ubuntu 24.04 ships gcc-13 by default, and Launchpad PPAs intermittently 504 from Azure-hosted GitHub runners).

C++ sources in `Assignment-{1..4}` weren't touched — they don't use any of the recently-renamed SVF APIs (`AbstractStateManager`, `AbstractState::storeValue`, `CallPE::getRHSVarID`, etc.).

## Test plan

- [ ] CI `Docker` workflow passes on this branch (the previously-failing job)
- [ ] CI `svf-teaching` workflow passes on Ubuntu + macOS