### PR TITLE
Declare AndersenPTA::processAllAddr in Assignment-3.h

### DIFF
--- a/Assignment-3/Assignment-3.h
+++ b/Assignment-3/Assignment-3.h
@@ -55,6 +55,9 @@ class AndersenPTA : public SVF::AndersenBase {
 	// To be implemented
 	void solveWorklist() override;
 
+	// Helper: initialise points-to sets from all Addr constraints
+	void processAllAddr();
+
 	/// Add copy edge on constraint graph
 	virtual bool addCopyEdge(SVF::NodeID src, SVF::NodeID dst) override {
 		if (consCG->addCopyCGEdge(src, dst))


### PR DESCRIPTION
The SVF-Teaching-Solutions Assignment-3.cpp defines `void AndersenPTA::processAllAddr()` as a helper called from solveWorklist (initialising points-to sets from address constraints), but the public skeleton never declared it.  CI 'replace assignments with solutions' then fails to compile the merged tree:

  Assignment-3/Assignment-3.cpp:89:6: error: no declaration matches
  'void AndersenPTA::processAllAddr()'

Add the declaration in the private section so the skeleton accepts the solution's definition (and any student solution following the same pattern).