### PR TITLE
Fix dev container build and GDB setup

### DIFF
--- a/.github/workflows/svf-teaching.yml
+++ b/.github/workflows/svf-teaching.yml
@@ -12,8 +12,8 @@ jobs:
         os: [ubuntu-24.04, macos-15]
     steps:
       # checkout the repo
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
 

--- a/.github/workflows/svf-teaching.yml
+++ b/.github/workflows/svf-teaching.yml
@@ -7,31 +7,22 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-    env:
-      XCODE_VERSION: '16.0.0'
+        os: [ubuntu-24.04, macos-15]
     steps:
       # checkout the repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 
-      # setup the mac/ubuntu environment
-      - name: mac-setup
-        if: runner.os == 'macOS'
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
-      - name: mac-setup-workaround
-        if: runner.os == 'macOS'
-        run: ln -sfn /Applications/Xcode_${{ env.XCODE_VERSION }}.app /Applications/Xcode.app
+      # setup the Ubuntu environment; macOS uses the runner's default Xcode
       - name: ubuntu-setup
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install cmake gcc g++ nodejs doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
+          sudo apt-get install -y cmake gcc g++ doxygen graphviz lcov libncurses5-dev libtinfo6 libzstd-dev
 
       # install llvm and svf
       - name: env-setup

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,6 +13,11 @@
             "MIMode": "gdb",
             "setupCommands": [
                 {
+                    "description": "Disable debuginfod downloads for system libraries",
+                    "text": "-gdb-set debuginfod enabled off",
+                    "ignoreFailures": true
+                },
+                {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,8 +3,10 @@
         {
             "label": "C/C++: cpp build active file",
             "type": "shell",
-            // if you run SVF-Teaching not in docker container, you need to change the LLVM_DIR and SVF_DIR
-            "command": "cmake -DCMAKE_BUILD_TYPE=Debug -DSVF_DIR=../SVF -DLLVM_DIR=../SVF/llvm-16.0.0.obj -DZ3_DIR=../SVF/z3.obj . && make",
+            // This assumes SVF is cloned and built next to Software-Analysis-Studio.
+            // SVF_DIR and LLVM_DIR point to the directories containing their
+            // *Config.cmake files. Change these paths if your layout is different.
+            "command": "cmake -DCMAKE_BUILD_TYPE=Debug -DSVF_DIR=../SVF/Debug-build/lib/cmake/SVF -DLLVM_DIR=../SVF/llvm-21.1.0.obj/lib/cmake/llvm -DZ3_DIR=../SVF/z3.obj . && make -j8",
             "options": {
                 "cwd": "${workspaceFolder}"
             },

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 # Stop ubuntu-20 interactive options.
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETPLATFORM
 
 # Stop script if any individual command fails.
@@ -19,7 +19,7 @@ ENV HOME=/home/SVF-tools
 # Launchpad PPA infrastructure has been intermittently unreachable
 # (HTTP 504 from add-apt-repository), and SVF itself does not pin a Python
 # version, so the base-image python is sufficient.
-ENV lib_deps="cmake g++ gcc git zlib1g-dev libncurses5-dev libtinfo6 build-essential libssl-dev libpcre2-dev zip libzstd-dev python3-dev"
+ENV lib_deps="cmake g++ gcc git zlib1g-dev libncurses5-dev libtinfo6 build-essential libssl-dev libpcre2-dev zip libzstd-dev python3-dev libc6-dbg"
 ENV build_deps="wget xz-utils git gdb tcl"
 
 # Fetch dependencies.
@@ -35,7 +35,7 @@ RUN echo "Building SVF ..."
 RUN bash ./build.sh debug
 
 # Export SVF, llvm, z3 paths
-ENV PATH=${HOME}/SVF/Release-build/bin:$PATH
+ENV PATH=${HOME}/SVF/Debug-build/bin:$PATH
 ENV PATH=${HOME}/SVF/llvm-$llvm_version.obj/bin:$PATH
 ENV SVF_DIR=${HOME}/SVF
 ENV LLVM_DIR=${HOME}/SVF/llvm-$llvm_version.obj
@@ -47,8 +47,17 @@ WORKDIR ${HOME}
 RUN git clone "https://github.com/SVF-tools/Software-Analysis-Studio.git"
 WORKDIR ${HOME}/Software-Analysis-Studio
 RUN echo "Building Software-Analysis-Studio ..."
-RUN sed -i 's/lldb/gdb/g' ${HOME}/Software-Analysis-Studio/.vscode/launch.json
-RUN cmake -DCMAKE_BUILD_TYPE=Debug .
+COPY .vscode/launch.json .vscode/launch.json
+COPY .vscode/tasks.json .vscode/tasks.json
+RUN cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DSVF_DIR="${SVF_DIR}/Debug-build/lib/cmake/SVF" \
+    -DLLVM_DIR="${LLVM_DIR}/lib/cmake/llvm" \
+    -DZ3_DIR="${Z3_DIR}" \
+    .
 RUN make -j8
+
+# GDB inside a Dev Container requires ptrace permissions at container runtime.
+LABEL devcontainer.metadata='[{"capAdd":["SYS_PTRACE"],"securityOpt":["seccomp=unconfined"]}]'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Summary:
- align the Docker image and VS Code task with the SVF Debug build and LLVM 21 CMake package directories
- copy the repository VS Code configurations into the image
- disable GDB debuginfod downloads by default to avoid debugger startup stalls
- add Dev Container ptrace metadata and explicitly install libc6-dbg

Validation:
- Docker build check completed without warnings
- full ARM64 image build completed successfully with Colima
- GDB reached main with SYS_PTRACE enabled and without the vDSO debuginfod stall
- git diff check passed