### PR TITLE
Prevent GDB debuginfod startup hangs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,11 +13,6 @@
             "MIMode": "gdb",
             "setupCommands": [
                 {
-                    "description": "Disable debuginfod downloads for system libraries",
-                    "text": "-gdb-set debuginfod enabled off",
-                    "ignoreFailures": true
-                },
-                {
                     "description": "Enable pretty-printing for gdb",
                     "text": "-enable-pretty-printing",
                     "ignoreFailures": true

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ ENV build_deps="wget xz-utils git gdb tcl"
 RUN apt-get update --fix-missing
 RUN apt-get install -y $build_deps $lib_deps
 
+# Prevent GDB from waiting for Ubuntu's remote debuginfod service.
+# Local debug symbols installed by packages such as libc6-dbg remain available.
+RUN rm -f /etc/debuginfod/*.urls
+
 # Fetch and build SVF source.
 RUN echo "Downloading LLVM and building SVF to " ${HOME}
 WORKDIR ${HOME}
@@ -56,8 +60,5 @@ RUN cmake \
     -DZ3_DIR="${Z3_DIR}" \
     .
 RUN make -j8
-
-# GDB inside a Dev Container requires ptrace permissions at container runtime.
-LABEL devcontainer.metadata='[{"capAdd":["SYS_PTRACE"],"securityOpt":["seccomp=unconfined"]}]'
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary
- remove Ubuntu debuginfod URL files from the image so cpptools 1.32.x cannot block on remote symbol downloads
- keep locally installed libc6-dbg symbols available
- remove the launch.json workaround that cpptools 1.32.x overrides
- remove the ineffective runtime-permission metadata label; the required docker run flags are now documented in the Wiki

## Verification
- docker build --check .
- reproduced the hang with the published ARM64 image and debuginfod enabled (timed out after 20 seconds)
- removed /etc/debuginfod/*.urls in an otherwise identical temporary container and GDB reached main immediately

Related upstream regression: microsoft/vscode-cpptools#14458