### PR TITLE
Use HelloWorld as the default debug target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,9 +5,9 @@
             "name": "(debug) Launch",
             "type": "cppdbg",
             "request": "launch",
-            // Please change to the executable of your current lab or assignment
-            "program": "${workspaceFolder}/bin/ass1",
-            "args": ["/home/SVF-tools/Software-Analysis-Studio/Assignment-1/test-exes/test1.graph.txt"], // may input the test llvm bc file or other options and flags the program may use
+            // Change this to the executable of your current lab or assignment.
+            "program": "${workspaceFolder}/bin/hello",
+            "args": [],
             "cwd": "${workspaceFolder}",
             "preLaunchTask": "C/C++: cpp build active file",
             "MIMode": "gdb",


### PR DESCRIPTION
## Summary
- make bin/hello the default VS Code F5 target
- remove the Assignment 1 input argument from the default configuration
- keep assignment-specific program and argument selection in the Wiki

## Verification
- Dockerfile validation passes
- bin/hello runs without arguments and prints Hello World!

The corresponding Wiki documentation was updated in one location only: Installation of Docker, VSCode and its extensions, section 2.1.